### PR TITLE
Enable smart sizing.

### DIFF
--- a/PuffinFeeder/src/main/java/edu/alaska/gina/feeder/puffinfeeder/ImageFeedFragment.java
+++ b/PuffinFeeder/src/main/java/edu/alaska/gina/feeder/puffinfeeder/ImageFeedFragment.java
@@ -198,7 +198,7 @@ public class ImageFeedFragment extends SherlockFragment {
 
         @Override
         public void onRequestFailure(SpiceException spiceException) {
-            Log.d(getString(R.string.app_tag), "Image Feed load fail!" + spiceException.getMessage());
+            Log.d(getString(R.string.app_tag), "Image Feed load fail! " + spiceException.getMessage());
             Toast.makeText(getActivity(), "Image Feed load fail!", Toast.LENGTH_SHORT).show();
             getSherlockActivity().setSupportProgressBarIndeterminateVisibility(false);
         }

--- a/PuffinFeeder/src/main/java/edu/alaska/gina/feeder/puffinfeeder/ImageViewerFragment.java
+++ b/PuffinFeeder/src/main/java/edu/alaska/gina/feeder/puffinfeeder/ImageViewerFragment.java
@@ -1,6 +1,8 @@
 package edu.alaska.gina.feeder.puffinfeeder;
 
 import android.content.SharedPreferences;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -77,20 +79,44 @@ public class ImageViewerFragment extends SherlockFragment{
         sharedPreferences.registerOnSharedPreferenceChangeListener(new SharedPreferences.OnSharedPreferenceChangeListener() {
             @Override
             public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
-                loadme();
+                loadme(pickLoadSize());
             }
         });
 
-        loadme();
+        loadme(pickLoadSize());
     }
 
-    private void loadme() {
-        if (sharedPreferences.getString("pref_viewer_image_size", "med").equals("small"))
+    private boolean isMetered(NetworkInfo net1) {
+        int type = net1.getType();
+        switch (type) {
+            case ConnectivityManager.TYPE_MOBILE:
+            case ConnectivityManager.TYPE_MOBILE_DUN:
+            case ConnectivityManager.TYPE_MOBILE_HIPRI:
+            case ConnectivityManager.TYPE_MOBILE_MMS:
+            case ConnectivityManager.TYPE_MOBILE_SUPL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private String pickLoadSize() {
+        ConnectivityManager cm = (ConnectivityManager) getActivity().getSystemService(getActivity().CONNECTIVITY_SERVICE);
+        NetworkInfo nf = cm.getActiveNetworkInfo();
+
+        if (sharedPreferences.getBoolean("pref_smart_sizing_on/off", true) && isMetered(nf))
+            return sharedPreferences.getString("pref_smart_sizing_size", "small");
+        else
+            return sharedPreferences.getString("pref_viewer_image_size", "med");
+    }
+
+    private void loadme(String size) {
+        if (size.equals("small"))
             image_frame.getSettings().setUseWideViewPort(false);
         else
             image_frame.getSettings().setUseWideViewPort(true);
 
-        image_frame.loadUrl(getImageUrl(sharedPreferences.getString("pref_viewer_image_size", "med")));
+        image_frame.loadUrl(getImageUrl(size));
     }
 
     private String getImageUrl(String sizeString) {

--- a/PuffinFeeder/src/main/java/edu/alaska/gina/feeder/puffinfeeder/ImageViewerFragment.java
+++ b/PuffinFeeder/src/main/java/edu/alaska/gina/feeder/puffinfeeder/ImageViewerFragment.java
@@ -104,10 +104,16 @@ public class ImageViewerFragment extends SherlockFragment{
         ConnectivityManager cm = (ConnectivityManager) getActivity().getSystemService(getActivity().CONNECTIVITY_SERVICE);
         NetworkInfo nf = cm.getActiveNetworkInfo();
 
-        if (sharedPreferences.getBoolean("pref_smart_sizing_on/off", true) && isMetered(nf))
-            return sharedPreferences.getString("pref_smart_sizing_size", "small");
-        else
+        if (nf != null) {
+            if (sharedPreferences.getBoolean("pref_smart_sizing_on/off", true) && isMetered(nf))
+                return sharedPreferences.getString("pref_smart_sizing_size", "small");
+            else
+                return sharedPreferences.getString("pref_viewer_image_size", "med");
+        }
+        else {
+            Log.d(getString(R.string.app_tag), "NetworkInfo null!");
             return sharedPreferences.getString("pref_viewer_image_size", "med");
+        }
     }
 
     private void loadme(String size) {

--- a/PuffinFeeder/src/main/res/values/strings.xml
+++ b/PuffinFeeder/src/main/res/values/strings.xml
@@ -25,4 +25,17 @@
     </string-array>
     <string name="pref_viewer_image_size_defaultValue">med</string>
 
+    <!-- Smart Sizing Selection Data -->
+    <string-array name="pref_smart_sizing_size_entries">
+        <item>Small</item>
+        <item>Normal</item>
+        <item>Large (WARNING: HIGH DATA USE!)</item>
+    </string-array>
+    <string-array name="pref_smart_sizing_size_entryValues">
+        <item>small</item>
+        <item>med</item>
+        <item>large</item>
+    </string-array>
+    <string name="pref_smart_sizing_size_defaultValue">small</string>
+
 </resources>

--- a/PuffinFeeder/src/main/res/xml/preferences.xml
+++ b/PuffinFeeder/src/main/res/xml/preferences.xml
@@ -10,4 +10,23 @@
         android:entryValues="@array/pref_viewer_image_size_entryValues"
         android:defaultValue="@string/pref_viewer_image_size_defaultValue" />
 
+    <SwitchPreference
+        android:key="pref_smart_sizing_on/off"
+        android:title="Smart Sizing"
+        android:summaryOff="Turning on makes the app use different images on 3G and 4G networks."
+        android:summaryOn="Select the size you want to use on 3G and 4G networks below."
+        android:disableDependentsState="false"
+        android:switchTextOff="Off"
+        android:switchTextOn="On"
+        android:defaultValue="true" />
+
+    <ListPreference
+        android:key="pref_smart_sizing_size"
+        android:dependency="pref_smart_sizing_on/off"
+        android:title="Select 3G/4G Image Size"
+        android:dialogTitle="Select Size:"
+        android:entries="@array/pref_smart_sizing_size_entries"
+        android:entryValues="@array/pref_smart_sizing_size_entryValues"
+        android:defaultValue="@string/pref_smart_sizing_size_defaultValue" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Allow app to choose what sized image to show based on network type (metered or not).
![smart_sizing-frame_nexus7](https://f.cloud.github.com/assets/4542458/881092/1309c610-f948-11e2-9bb5-2a6fcd0afc01.png)
